### PR TITLE
13: Struct constructor replacement factories

### DIFF
--- a/13/main.go
+++ b/13/main.go
@@ -1,0 +1,29 @@
+package main
+
+import "fmt"
+
+// Car ...(exportable since its uppercase)
+type Car struct {
+	Model string
+	Year  int
+}
+
+// NewCar ...(exportable since its uppercase)
+// This is a replacement for a struct constructor
+// using somewhat of a factory pattern
+// Standard Format for such a function is
+// func New<struct type>(input arguments) (return pointer or value) {
+//   return <struct type>{input arguments} // Value
+//   OR
+//   return &<struct type>{input arguments} // Pointer to a value
+// }
+func NewCar(model string, year int) *Car {
+	return &Car{model, year}
+}
+
+func main() {
+	c := NewCar("Honda", 1980)
+
+	fmt.Println("Car instance: ", c)
+	// This will print `Car instance:  &{Honda 1980}`
+}


### PR DESCRIPTION
# Overview
Golang structs dont have constructors.
A common pattern that the golang community uses to mock the constructors, is to 
use a factory pattern of a specific format.

Format:
```
func New<struct type>(input arguments) (return pointer or value) {
  return <struct type>{input arguments} // Value
  OR
  return &<struct type>{input arguments} // Pointer to a value 
}
```

Golang does not require the above format for compilation.
This is more of a common standard pattern used by the community.