### PR TITLE
[HTTP] Server: Basic HTTP Server Usage

### DIFF
--- a/LessBasic/2/server/main.go
+++ b/LessBasic/2/server/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	// Mock helper struct to marshal the mock message into a json object
+	type testMessage struct {
+		Message string `json:"message"`
+	}
+
+	// Serving the route `localhost:8080/api/v1/test`
+	http.HandleFunc("/api/v1/test", func(w http.ResponseWriter, r *http.Request) {
+		// Create a mock json response for the test
+		b, err := json.Marshal(testMessage{"A test message."})
+		if err != nil {
+			http.Error(w, "Internal Server Error", 500)
+			return
+		}
+
+		// Set and send the response to the http.ResponseWriter
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, string(b))
+	})
+
+	// This binary will start listening to any messages that it receives
+	// on the port 8080
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
# Overview
This PR adds a simple example for a mock http server.
The server listens on port 8080 for a versioned api path and returns a mock message as response.